### PR TITLE
fix to able to run release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
+          cache: false # lock file が存在しないため、キャッシュを無効化
       - name: Publish and Release
         uses: akashic-games/action-release@a81329f4a70100c4729df80dba17ec8d5da52511 # v3.1.1
         with:


### PR DESCRIPTION
### やったこと
- release.yml で actions/setup-node 実行時にキャッシュ無効化(lock file が存在しないため)