### PR TITLE
add package-manager-cache option when use actions/setup-node in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: false # lock file が存在しないため、キャッシュを無効化
+          package-manager-cache: false # lock file が存在しないため、キャッシュを無効化
       - name: Publish and Release
         uses: akashic-games/action-release@a81329f4a70100c4729df80dba17ec8d5da52511 # v3.1.1
         with:


### PR DESCRIPTION
### やったこと
- release.ymlでactions/setup-node使用時に`package-manager-cache:false`を指定